### PR TITLE
Using new Timer class abstraction rather than direct access to millis().

### DIFF
--- a/Firecracker.ino
+++ b/Firecracker.ino
@@ -40,7 +40,7 @@ static int sourceFace=NO_FACE; // The face we got the spark from.
 static int targetFace=NO_FACE; // The face we are sending the spark to.
                                // Only matters in BURN state. NO_FACE if we are not spreading
 
-static uint32_t nextStateTime;        // Time we switch to next state. Valid in EXPLODING, COOLDOWN, and INFECT.
+Timer nextState;         // Time we switch to next state. Valid in EXPLODING, COOLDOWN, and INFECT.
 
 // How long between when we first get a spark and start sending a new spark
 static const uint16_t igniteDurration_ms = 200;
@@ -99,8 +99,9 @@ static byte pickSparkTarget( byte exclude ) {
 
 void loop() {
         
+         
     // put your main code here, to run repeatedly:
-    uint32_t now = millis();
+
   
     bool detonateFlag = false;        // Set this flag to true to cause detonation
                                       // since the ignition can come from either button or spark
@@ -146,10 +147,10 @@ void loop() {
   
     if (detonateFlag) {
         state=IGNITE;
-        nextStateTime=now+igniteDurration_ms;
+        nextState.setMSFromNow( igniteDurration_ms );
     }      
       
-    if ( nextStateTime < now ) {        // Time for next timed state transition?
+    if ( nextState.isExpired() ) {        // Time for next timed state transition?
         
         // These are the only states that can timeout
         
@@ -162,12 +163,12 @@ void loop() {
             targetFace = pickSparkTarget( sourceFace );
             
             state=BURN;
-            nextStateTime=now+burnDuration_ms;
+            nextState.setMSFromNow( burnDuration_ms );
             
         } else if (state==BURN) {              // Technically don't need this `if` since this is the only possible case, but here for clarity.             
             
             state=READY;
-            nextStateTime=NEVER;                 
+            nextState.setNever();                 
             
         }                
                 


### PR DESCRIPTION
The change is subtle, but abstracts away millis() so people don't even know what type it is. 

Also automatically gets rid of some race conditions and boundary problems people are likely to have writing this stuff over and over again on their own. 

Finally, opens opportunities for optimization by, say, internally processing ticks rather than milliseconds, in which case we only have to do the conversion a single time when the timer is set- and even then that can happen at compile time for constant values.  